### PR TITLE
chore: npm i zenn-cli@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "zenn-cli": "^0.1.75"
+        "zenn-cli": "^0.1.159"
       }
     },
     "node_modules/zenn-cli": {
-      "version": "0.1.137",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.137.tgz",
-      "integrity": "sha512-WE0L9ZKlWZdpr+O8EMnIEaQDNmGe8eg0n71KifVB2n1g9vYVP0hfTKWondT4FYpIJidQ3IDSHW7TyKIOSgi/xA==",
+      "version": "0.1.159",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.159.tgz",
+      "integrity": "sha512-a4/Lkg3DnxWlYh2Z0abuvvmpQc0BnfTQrVyNQxYm+IOrwGJepZabwWTT0Q3eZ3r7hAV/xd8MZsmZL3y3pzMpAA==",
+      "license": "MIT",
       "bin": {
         "zenn": "dist/server/zenn.js"
       },
@@ -26,9 +27,9 @@
   },
   "dependencies": {
     "zenn-cli": {
-      "version": "0.1.137",
-      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.137.tgz",
-      "integrity": "sha512-WE0L9ZKlWZdpr+O8EMnIEaQDNmGe8eg0n71KifVB2n1g9vYVP0hfTKWondT4FYpIJidQ3IDSHW7TyKIOSgi/xA=="
+      "version": "0.1.159",
+      "resolved": "https://registry.npmjs.org/zenn-cli/-/zenn-cli-0.1.159.tgz",
+      "integrity": "sha512-a4/Lkg3DnxWlYh2Z0abuvvmpQc0BnfTQrVyNQxYm+IOrwGJepZabwWTT0Q3eZ3r7hAV/xd8MZsmZL3y3pzMpAA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/oke-py/zenn-content#readme",
   "dependencies": {
-    "zenn-cli": "^0.1.75"
+    "zenn-cli": "^0.1.159"
   }
 }


### PR DESCRIPTION
## 概要
zenn-cliパッケージを最新バージョンにアップデートしました。

## 変更内容
- `npm i zenn-cli@latest` を実行し、zenn-cliを最新バージョンに更新
- これにより、Zenn記事の執筆とプレビューに関する最新機能や改善点が利用可能になります

## 動作確認
- ローカル環境で `npx zenn preview` を実行し、正常に動作することを確認済み

## 関連情報
- [zenn-cliのリリースノート](https://github.com/zenn-dev/zenn-editor/releases)